### PR TITLE
Add prepare: husky to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint-prettier-javascript": "prettier --check \"./**/*.js\"",
     "lint-prettier-typescript": "prettier --check --parser typescript \"./**/*.{ts,tsx}\"",
     "lint-tsc": "tsc --noEmit",
+    "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "test": "echo \"Error: no test specified\" && exit 1",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",


### PR DESCRIPTION
This command is what generates the _ folder in .husky, which tells it what to do on commit. If this folder is not present, pre-commits will not run.