### PR TITLE
Add --frozen-lockfile to pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: corepack enable && corepack prepare pnpm@latest --activate
         
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build package
         run: pnpm run build --if-present

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       
       - name: Build package
         run: pnpm run build


### PR DESCRIPTION
This ensures that the script errors if pnpm install will change the lockfile, similarly to what npm ci does.