### PR TITLE
Add --no-frozen-lockfile to update-dependencies script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint-tsc": "tsc --noEmit",
     "prepare": "husky",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "update-dependencies": "bash -c 'pnpx npm-check-updates -p pnpm -u \"$@\" && pnpm install' --",
+    "update-dependencies": "bash -c 'pnpx npm-check-updates -p pnpm -u \"$@\" && pnpm install --no-frozen-lockfile' --",
     "use-live-eslint-plugin": "pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev @alextheman/eslint-plugin",
     "use-local-eslint-plugin": "npm --prefix ../eslint-plugin run create-local-package && pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev ../eslint-plugin/alextheman-eslint-plugin-*.tgz"
   },


### PR DESCRIPTION
Apparently, PNPM uses --frozen-lockfile in the GitHub Actions by default. This is a smart idea, to be fair, as it ensures that the CI environment doesn't unintentionally change the lockfile, but for the update action to run, we need to change the lockfile. As such, we need to add the --no-frozen-lockfile flag so that the update-dependencies action can actually update.