### PR TITLE
Add || true to publish step in publish script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,4 +34,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public || true


### PR DESCRIPTION
This will fail if the version number did not change, but I do often find myself making pull requests without changing the version number (e.g. for config changes that don't affect the source code). As such, I feel like it may be best to just add || true to avoid the script from displaying as a failure just because the version did not change. I can find out if it legitimately failed anyway by checking my emails and/or the logs.